### PR TITLE
fixing comparison logic

### DIFF
--- a/service/templates/istio-policy.yaml
+++ b/service/templates/istio-policy.yaml
@@ -1,5 +1,5 @@
 {{- $auth := pluck .Values.environment .Values.auth | first | default .Values.auth._default -}}
-{{ if ne $auth.enabled true -}}
+{{ if eq $auth.enabled true -}}
 apiVersion: "authentication.istio.io/v1alpha1"
 kind: "Policy"
 metadata:


### PR DESCRIPTION
Found a small error that was causing a policy to be created when it shouldn't and vice versa. 